### PR TITLE
Add EPA and logo download helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
 # Nflstats
+
+## Data Sources
+
+### Expected Points Added (EPA)
+- **Provider:** nflfastR weekly CSVs via GitHub Releases (public data snapshot).
+- **Endpoint:** `https://github.com/guga31bb/nflfastR-data/tree/master/data` with per-season play-by-play files (e.g., `https://raw.githubusercontent.com/guga31bb/nflfastR-data/master/data/play_by_play_2023.csv.gz`).
+- **Required parameters:**
+  - Season year embedded in filename (e.g., `play_by_play_2023.csv.gz`).
+  - Optional downstream filters applied after download (week, team, offense/defense splits).
+- **Update cadence:** Files updated weekly in-season after games conclude (typically within 24 hours); historical seasons are static snapshots.
+
+### Team Logos
+- **Source:** GitHub-hosted SVG/PNG set from `https://github.com/ryanmcdermott/nfl-logos`.
+- **Access:** Direct raw file URLs under `https://raw.githubusercontent.com/ryanmcdermott/nfl-logos/master/` (e.g., `png/<team>.png` or `svg/<team>.svg`).
+- **Attribution/Licensing:** Repository notes assets are for informational/educational use and originate from public logo vectors; verify trademark usage before production deployment.
+
+## Required Data Fields
+To support EPA reporting by team and time period, the ingest should capture:
+- **Team identifier:** Club code matching nflfastR team abbreviations (e.g., `KC`, `PHI`).
+- **Offensive EPA/play:** Aggregate or per-play `epa` values when the team is on offense.
+- **Defensive EPA/play:** Aggregate or per-play `epa` values when the team is on defense (opponent offense).
+- **Season filter:** Ability to select a given season year from the play-by-play dataset.
+- **Week filter:** Ability to limit computations to specific weeks within a season.
+
+## Notes
+- EPA calculations and team splits are derived from the nflfastR play-by-play dataset after download.
+- Logo filenames follow lowercase team abbreviations (e.g., `png/kc.png`); map identifiers accordingly.
+
+## Implementation Helpers
+Use `sources.py` to work with the documented endpoints directly:
+
+```python
+from pathlib import Path
+from sources import download_epa_csv, download_team_logo
+
+# Download gzipped play-by-play CSV for 2023 into ./data
+epa_path = download_epa_csv(2023)
+
+# Download the Chiefs PNG logo into ./logos/png
+logo_path = download_team_logo("KC", fmt="png")
+
+print("EPA file saved to", epa_path)
+print("Logo saved to", logo_path)
+```

--- a/sources.py
+++ b/sources.py
@@ -1,0 +1,89 @@
+"""Utilities for accessing EPA and logo assets from documented sources.
+
+This module keeps code and documentation aligned by encapsulating the URLs
+and download helpers described in the README. Only the standard library is
+used to avoid extra runtime dependencies.
+"""
+from pathlib import Path
+from typing import Literal
+from urllib.request import urlopen
+import shutil
+
+EPA_BASE_URL = "https://raw.githubusercontent.com/guga31bb/nflfastR-data/master/data"
+LOGO_BASE_URL = "https://raw.githubusercontent.com/ryanmcdermott/nfl-logos/master"
+
+LogoFormat = Literal["png", "svg"]
+
+
+def epa_csv_url(season: int) -> str:
+    """Build the nflfastR play-by-play CSV URL for a season.
+
+    Args:
+        season: Season year (e.g., 2023).
+
+    Returns:
+        Fully qualified HTTPS URL for the gzipped CSV file.
+    """
+    return f"{EPA_BASE_URL}/play_by_play_{season}.csv.gz"
+
+
+def logo_url(team_abbr: str, fmt: LogoFormat = "png") -> str:
+    """Build the URL for a team logo asset.
+
+    Args:
+        team_abbr: Team abbreviation (e.g., "KC", "PHI").
+        fmt: File format extension (png or svg).
+
+    Returns:
+        HTTPS URL for the requested logo asset.
+    """
+    normalized_team = team_abbr.lower()
+    return f"{LOGO_BASE_URL}/{fmt}/{normalized_team}.{fmt}"
+
+
+def download_file(url: str, destination: Path) -> Path:
+    """Download a remote asset to a destination path.
+
+    Parent directories are created automatically. The function streams the
+    response directly to disk to keep memory usage predictable for large EPA
+    CSV files.
+    """
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with urlopen(url) as response, destination.open("wb") as output:
+        shutil.copyfileobj(response, output)
+    return destination
+
+
+def download_epa_csv(season: int, target_dir: Path | None = None) -> Path:
+    """Download a season's nflfastR play-by-play CSV.
+
+    Args:
+        season: Season year to retrieve.
+        target_dir: Optional directory for the downloaded file. Defaults to
+            a local "data" directory under the repository root.
+
+    Returns:
+        Path to the downloaded gzipped CSV file.
+    """
+    directory = target_dir or Path("data")
+    url = epa_csv_url(season)
+    destination = directory / f"play_by_play_{season}.csv.gz"
+    return download_file(url, destination)
+
+
+def download_team_logo(team_abbr: str, fmt: LogoFormat = "png", target_dir: Path | None = None) -> Path:
+    """Download a team logo asset.
+
+    Args:
+        team_abbr: Team abbreviation matching logo filenames (e.g., "KC").
+        fmt: Desired logo format (png or svg).
+        target_dir: Optional directory for downloaded logos. Defaults to a
+            "logos" directory under the repository root.
+
+    Returns:
+        Path to the downloaded logo file.
+    """
+    directory = target_dir or Path("logos") / fmt
+    url = logo_url(team_abbr, fmt)
+    destination = directory / f"{team_abbr.lower()}.{fmt}"
+    return download_file(url, destination)


### PR DESCRIPTION
## Summary
- add a standard-library helper module that builds EPA and logo URLs and downloads assets
- document how to call the helpers alongside the existing data source notes

## Testing
- python -m py_compile sources.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69454f5560ac83318f4932b2e3b1c078)