### PR TITLE
Use text fallback sample for EPA data

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ targets (see [Run end-to-end](#run-end-to-end)).
 ## Data Sources
 
 ### Expected Points Added (EPA)
-- **Provider:** nflfastR weekly CSVs via GitHub Releases (public data snapshot).
-- **Endpoint:** `https://github.com/guga31bb/nflfastR-data/tree/master/data` with per-season play-by-play files (e.g., `https://raw.githubusercontent.com/guga31bb/nflfastR-data/master/data/play_by_play_2023.csv.gz`).
+- **Provider:** nflfastR weekly CSVs via the maintained `nflverse-data` snapshot on GitHub.
+- **Endpoint:** `https://github.com/nflverse/nflverse-data/tree/master/data` with per-season play-by-play files (e.g., `https://raw.githubusercontent.com/nflverse/nflverse-data/master/data/play_by_play_2023.csv.gz`).
+- **Offline fallback:** A minimal plain-text sample file lives at `data/play_by_play_sample.csv` and is gzipped on the fly when
+  the live download is unavailable (for example, in offline CI).
 - **Required parameters:**
   - Season year embedded in filename (e.g., `play_by_play_2023.csv.gz`).
   - Optional downstream filters applied after download (week, team, offense/defense splits).

--- a/data/play_by_play_sample.csv
+++ b/data/play_by_play_sample.csv
@@ -1,0 +1,5 @@
+season_type,week,posteam,defteam,epa,wp
+REG,1,KC,DET,0.5,0.6
+REG,1,DET,KC,-0.3,0.4
+REG,2,PHI,DAL,0.1,0.55
+REG,2,DAL,PHI,-0.2,0.45

--- a/sources.py
+++ b/sources.py
@@ -5,12 +5,16 @@ and download helpers described in the README. Only the standard library is
 used to avoid extra runtime dependencies.
 """
 from pathlib import Path
+import gzip
 from typing import Literal
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 import shutil
 
-EPA_BASE_URL = "https://raw.githubusercontent.com/guga31bb/nflfastR-data/master/data"
+# The nflfastR data repository moved to the `nflverse` organization. The previous
+# `guga31bb/nflfastR-data` location is no longer updated and returns 404s for
+# newer seasons, so point to the maintained source instead.
+EPA_BASE_URL = "https://raw.githubusercontent.com/nflverse/nflverse-data/master/data"
 LOGO_BASE_URL = "https://raw.githubusercontent.com/ryanmcdermott/nfl-logos/master"
 
 LogoFormat = Literal["png", "svg"]
@@ -64,13 +68,17 @@ def download_file(url: str, destination: Path) -> Path:
     return destination
 
 
-def download_epa_csv(season: int, target_dir: Path | None = None) -> Path:
+def download_epa_csv(
+    season: int, target_dir: Path | None = None, *, fallback_sample: Path | None = None
+) -> Path:
     """Download a season's nflfastR play-by-play CSV.
 
     Args:
         season: Season year to retrieve.
         target_dir: Optional directory for the downloaded file. Defaults to
             a local "data" directory under the repository root.
+        fallback_sample: Optional local gzipped CSV to copy into place when the
+            remote download fails (useful for offline runs).
 
     Returns:
         Path to the downloaded gzipped CSV file.
@@ -78,7 +86,19 @@ def download_epa_csv(season: int, target_dir: Path | None = None) -> Path:
     directory = target_dir or Path("data")
     url = epa_csv_url(season)
     destination = directory / f"play_by_play_{season}.csv.gz"
-    return download_file(url, destination)
+
+    try:
+        return download_file(url, destination)
+    except (FileNotFoundError, ConnectionError):
+        if fallback_sample and fallback_sample.exists():
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            if fallback_sample.suffix == ".gz":
+                shutil.copy(fallback_sample, destination)
+            else:
+                with fallback_sample.open("rb") as source, gzip.open(destination, "wb") as gz_target:
+                    shutil.copyfileobj(source, gz_target)
+            return destination
+        raise
 
 
 def download_team_logo(team_abbr: str, fmt: LogoFormat = "png", target_dir: Path | None = None) -> Path:


### PR DESCRIPTION
## Summary
- replace the bundled gzipped EPA fallback with a small plain-text CSV sample
- gzip the fallback sample on the fly when remote downloads fail and infer compression when reading
- document the updated offline behavior in the README

## Testing
- python -m scripts.fetch_epa --season 2023 --data-dir data --output data/team_epa_2023_test.csv --force-download

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694572f3a9a483319d1ab97d59b54b15)