### PR TITLE
Add manual workflow to generate EPA chart artifacts

### DIFF
--- a/.github/workflows/generate-epa-chart.yml
+++ b/.github/workflows/generate-epa-chart.yml
@@ -1,0 +1,81 @@
+name: Generate EPA chart
+
+on:
+  workflow_dispatch:
+    inputs:
+      season:
+        description: "Season year to download and chart (e.g., 2025)"
+        required: true
+        default: "2025"
+      week_start:
+        description: "Optional starting week to include"
+        required: false
+      week_end:
+        description: "Optional ending week to include"
+        required: false
+      min_wp:
+        description: "Minimum win probability filter (0-1)"
+        required: false
+      max_wp:
+        description: "Maximum win probability filter (0-1)"
+        required: false
+      include_playoffs:
+        description: "Include postseason plays"
+        required: false
+        default: "false"
+        type: boolean
+      week_label:
+        description: "Custom subtitle label for the week range"
+        required: false
+      invert_y:
+        description: "Invert defensive EPA axis so better defenses trend upward"
+        required: false
+        default: "true"
+        type: boolean
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Build EPA dataset and chart
+        env:
+          SEASON: ${{ inputs.season }}
+          WEEK_START: ${{ inputs.week_start }}
+          WEEK_END: ${{ inputs.week_end }}
+          MIN_WP: ${{ inputs.min_wp }}
+          MAX_WP: ${{ inputs.max_wp }}
+          WEEK_LABEL: ${{ inputs.week_label }}
+        run: |
+          set -e
+          if [ "${{ inputs.include_playoffs }}" = "true" ]; then
+            export INCLUDE_PLAYOFFS=1
+          fi
+          if [ "${{ inputs.invert_y }}" = "true" ]; then
+            export INVERT_Y=1
+          fi
+
+          make logos
+          make fetch-epa
+          make plot-epa
+
+      - name: Upload EPA chart artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: epa-chart-${{ inputs.season }}
+          path: |
+            data/team_epa_${{ inputs.season }}.csv
+            plots/epa_scatter.png

--- a/README.md
+++ b/README.md
@@ -113,6 +113,27 @@ make refresh SEASON=2023    # Run all the above in order
 The Make targets use `python -m scripts.<task>` so they work in both virtual
 environments and system installs.
 
+## Generate the chart via GitHub Actions
+
+Trigger the `Generate EPA chart` workflow manually from the GitHub Actions tab
+to produce a fresh plot and aggregate CSV without running anything locally.
+
+Inputs you can customize when dispatching:
+- **season** (default `2025`): Season year to download and chart.
+- **week_start/week_end** (optional): Limit the data to a week range before
+  aggregation.
+- **min_wp/max_wp** (optional): Filter plays by win probability bounds.
+- **include_playoffs** (default `false`): Include postseason plays in the
+  aggregation.
+- **week_label** (optional): Subtitle text describing the week window on the
+  plot.
+- **invert_y** (default `true`): Invert the defensive EPA axis so better
+  defenses trend upward.
+
+The workflow installs dependencies, caches logos, fetches the EPA data, renders
+the plot (defaulting to `plots/epa_scatter.png`), and uploads both the plot and
+`data/team_epa_<season>.csv` as downloadable workflow artifacts.
+
 ## Required Data Fields
 To support EPA reporting by team and time period, the ingest should capture:
 - **Team identifier:** Club code matching nflfastR team abbreviations (e.g., `KC`, `PHI`).


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions workflow to generate the EPA dataset and plot via the existing make targets
- upload the aggregated CSV and scatter plot as workflow artifacts for the chosen season
- document how to dispatch the workflow and customize inputs in the README

## Testing
- python -m compileall .


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a48d66d08331a6609be0fc2ca4c7)