### PR TITLE
Add EPA data fetcher workflow

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1,0 +1,26 @@
+name: Run EPA data fetcher
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main", "work"]
+
+jobs:
+  run-epa:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run EPA fetcher
+        run: python main.py

--- a/epa_od_fetcher.py
+++ b/epa_od_fetcher.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import nfl_data_py as nfl
+
+
+def download_pbp(year: int) -> pd.DataFrame:
+    """Download play-by-play data for the given season including EPA."""
+    return nfl.import_pbp_data(years=[year], cache=True)
+
+
+def compute_team_epa(pbp: pd.DataFrame) -> pd.DataFrame:
+    """Compute per-team offensive and defensive EPA metrics."""
+    pbp = pbp[pbp["epa"].notna()]
+
+    off = (
+        pbp.groupby("posteam")["epa"]
+        .agg(["sum", "count"])
+        .rename(columns={"sum": "EPA_off_total", "count": "Plays_off"})
+    )
+    off["EPA_off_per_play"] = off["EPA_off_total"] / off["Plays_off"]
+
+    defn = (
+        pbp.groupby("defteam")["epa"]
+        .agg(["sum", "count"])
+        .rename(columns={"sum": "EPA_def_total", "count": "Plays_def"})
+    )
+    defn["EPA_def_per_play"] = -defn["EPA_def_total"] / defn["Plays_def"]
+
+    return pd.concat([off, defn], axis=1).fillna(0)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from epa_od_fetcher import compute_team_epa, download_pbp
+
+
+def main() -> None:
+    year = 2023
+    print(f"Downloading PBP data for {year} ...")
+    pbp = download_pbp(year)
+
+    print("Computing EPA by team ...")
+    team_epa = compute_team_epa(pbp)
+    print(team_epa)
+
+    output_dir = Path("data")
+    output_dir.mkdir(exist_ok=True)
+    output_path = output_dir / f"nfl_{year}_team_epa.csv"
+    team_epa.to_csv(output_path)
+    print(f"Saved {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add an EPA offense/defense fetcher utility for downloading and aggregating play-by-play data
- add a main entry script that prints team EPA metrics and saves them to the data directory
- create a GitHub Actions workflow to install dependencies and run the fetcher script

## Testing
- python -m compileall main.py epa_od_fetcher.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694614bd3a1c8331ae730f772ae190a8)