### PR TITLE
Save EPA scatter outputs to repository root

### DIFF
--- a/.github/workflows/generate-epa-chart.yml
+++ b/.github/workflows/generate-epa-chart.yml
@@ -83,7 +83,7 @@ jobs:
           <body>
             <h1>NFL Offense vs Defense Efficiency (EPA/play)</h1>
             <p>Season: ${{ inputs.season }}</p>
-            <img src="plots/epa_scatter.png" alt="EPA scatter plot" style="max-width: 100%; height: auto;">
+            <img src="epa_scatter.png" alt="EPA scatter plot" style="max-width: 100%; height: auto;">
           </body>
           </html>
           EOF
@@ -92,7 +92,7 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add plots/epa_scatter.png index.html
+          git add epa_scatter.png index.html
           git commit -m "Update EPA scatter plot and index.html"
           git push origin HEAD:main
         env:
@@ -104,4 +104,4 @@ jobs:
           name: epa-chart-${{ inputs.season }}
           path: |
             data/team_epa_${{ inputs.season }}.csv
-            plots/epa_scatter.png
+            epa_scatter.png

--- a/README.md
+++ b/README.md
@@ -85,17 +85,17 @@ With the aggregated data and logos in place, render the offense vs defense
 scatter chart:
 
 ```bash
-python -m scripts.plot_epa_scatter --season 2023 --week "Weeks 1-10" --output plots/epa_scatter.png
+python -m scripts.plot_epa_scatter --season 2023 --week "Weeks 1-10" --output epa_scatter.png
 ```
 
 The script will read `data/team_epa_<season>.csv` by default and saves PNG
-output to `plots/epa_scatter.png`, optionally alongside SVG/PDF copies via
+output to `epa_scatter.png`, optionally alongside SVG/PDF copies via
 `--svg`/`--pdf`. Use `--invert-y` to flip the defensive EPA axis so better
 defenses appear higher on the chart. Combine this with the filters above to
 mirror the example tiers chart:
 
 ```bash
-python -m scripts.plot_epa_scatter --season 2022 --week "Weeks 8-15 (win prob 10-90%)" --invert-y --output plots/epa_scatter_2022_w8_15.png
+python -m scripts.plot_epa_scatter --season 2022 --week "Weeks 8-15 (win prob 10-90%)" --invert-y --output epa_scatter_2022_w8_15.png
 ```
 
 ## Run end-to-end
@@ -106,7 +106,7 @@ A lightweight `Makefile` provides shortcuts for common tasks. Override the
 ```bash
 make logos                # Cache logos into assets/logos (placeholders if offline)
 make fetch-epa SEASON=2023 WEEK_START=8 WEEK_END=15 MIN_WP=0.1 MAX_WP=0.9  # Download + summarize with filters
-make plot-epa SEASON=2023 WEEK_LABEL="Weeks 8-15 (win prob 10-90%)" INVERT_Y=1  # Render plots/epa_scatter.png with labels and inverted y-axis
+make plot-epa SEASON=2023 WEEK_LABEL="Weeks 8-15 (win prob 10-90%)" INVERT_Y=1  # Render epa_scatter.png with labels and inverted y-axis
 make refresh SEASON=2023    # Run all the above in order
 ```
 
@@ -131,7 +131,7 @@ Inputs you can customize when dispatching:
   defenses trend upward.
 
 The workflow installs dependencies, caches logos, fetches the EPA data, renders
-the plot (defaulting to `plots/epa_scatter.png`), and uploads both the plot and
+the plot (defaulting to `epa_scatter.png`), and uploads both the plot and
 `data/team_epa_<season>.csv` as downloadable workflow artifacts.
 
 ## Required Data Fields

--- a/index.html
+++ b/index.html
@@ -38,6 +38,6 @@
 <body>
   <h1>NFL EPA Scatter</h1>
   <p>This chart plots each team's offensive EPA per play against defensive EPA per play using small squares colored by the team's primary color.</p>
-  <img class="chart" src="plots/epa_team_colors.png" alt="EPA offense vs defense scatter plot">
+  <img class="chart" src="epa_scatter.png" alt="EPA offense vs defense scatter plot">
 </body>
 </html>

--- a/scripts/plot_epa_scatter.py
+++ b/scripts/plot_epa_scatter.py
@@ -53,7 +53,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--output",
         type=Path,
-        default=Path("plots") / "epa_scatter.png",
+        # Save the plot in the repository root by default instead of under the plots/ directory.
+        default=Path("epa_scatter.png"),
         help="Output PNG path for the scatter plot",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- default EPA scatter plotting script to write epa_scatter.png in the repository root
- adjust workflow commit/upload paths and HTML image reference to the new location
- update README and index page to describe the root-level output

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c1c3c9a48331861e4d306ed6fe28)