### PR TITLE
Add simple EPA plotting utilities

### DIFF
--- a/plot_epa_bar_chart.py
+++ b/plot_epa_bar_chart.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def plot_offense_bar_chart(csv_path: str) -> str:
+    """Plot a bar chart of offensive EPA per play by team."""
+    df = pd.read_csv(csv_path)
+    df = df.sort_values("EPA_off_per_play", ascending=False)
+
+    plots_dir = Path("plots")
+    plots_dir.mkdir(exist_ok=True)
+    output_path = plots_dir / "offense_epa_bar.png"
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.bar(df["team"], df["EPA_off_per_play"], color="seagreen")
+    ax.set_ylabel("Offensive EPA per play")
+    ax.set_xlabel("Team")
+    ax.set_title("Offensive EPA per play by Team")
+    ax.tick_params(axis="x", rotation=45)
+
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+    return str(output_path)

--- a/plot_epa_offense_defense.py
+++ b/plot_epa_offense_defense.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def plot_offense_vs_defense(csv_path: str) -> str:
+    """Plot offense vs defense EPA with a diagonal reference line."""
+    df = pd.read_csv(csv_path)
+    plots_dir = Path("plots")
+    plots_dir.mkdir(exist_ok=True)
+    output_path = plots_dir / "offense_vs_defense.png"
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+    ax.scatter(df["EPA_off_per_play"], df["EPA_def_per_play"], color="darkorange")
+    ax.plot([-0.5, 0.5], [-0.5, 0.5], linestyle="--", color="grey", linewidth=0.7)
+    for _, row in df.iterrows():
+        ax.text(row["EPA_off_per_play"], row["EPA_def_per_play"], row["team"], fontsize=8)
+
+    ax.set_xlabel("Offensive EPA per play")
+    ax.set_ylabel("Defensive EPA per play")
+    ax.set_title("Offense vs Defense EPA")
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+    return str(output_path)

--- a/plotepa.py
+++ b/plotepa.py
@@ -1,0 +1,39 @@
+import os
+from pathlib import Path
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def plot_epa(csv_path: str) -> str:
+    """Create a simple EPA scatter plot for offense vs defense.
+
+    Parameters
+    ----------
+    csv_path: str
+        Path to a CSV containing columns ``team``, ``EPA_off_per_play`` and
+        ``EPA_def_per_play``.
+
+    Returns
+    -------
+    str
+        File path to the saved plot image.
+    """
+    df = pd.read_csv(csv_path)
+    plots_dir = Path("plots")
+    plots_dir.mkdir(exist_ok=True)
+    output_path = plots_dir / "epa_scatter.png"
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+    ax.scatter(df["EPA_off_per_play"], df["EPA_def_per_play"], color="steelblue")
+    for _, row in df.iterrows():
+        ax.text(row["EPA_off_per_play"], row["EPA_def_per_play"], row["team"], fontsize=8)
+
+    ax.set_xlabel("Offensive EPA per play")
+    ax.set_ylabel("Defensive EPA per play (higher is better)")
+    ax.axvline(0, color="grey", linestyle="--", linewidth=0.7)
+    ax.axhline(0, color="grey", linestyle="--", linewidth=0.7)
+
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+    return str(output_path)


### PR DESCRIPTION
## Summary
- add lightweight plotting helpers for EPA scatter, offense-defense comparison, and offensive bar chart
- ensure plots are written to the plots directory with basic labeling

## Testing
- python -m py_compile main.py plotepa.py plot_epa_offense_defense.py plot_epa_bar_chart.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694768ad4e24833198b89109144549c3)