### PR TITLE
Update Main workflow to use scripts pipeline

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -26,11 +26,16 @@ jobs:
         run: |
           python -c "import pandas, matplotlib, requests, polars, pyarrow; from PIL import Image; import nflreadpy; print('deps ok')"
 
-      - name: Run script
-        env:
-          NFL_SEASON: "2025"
+      - name: Ensure data directory
+        run: mkdir -p data
+
+      - name: Build team EPA CSV
         run: |
-          python main.py
+          python -m scripts.fetch_epa --season 2025 --include-playoffs
+
+      - name: Plot EPA scatter
+        run: |
+          python -m scripts.plot_epa_scatter --season 2025
 
       - name: Plot team color squares
         run: python plot_team_color_squares.py


### PR DESCRIPTION
## Summary
- replace the Main workflow's main.py invocation with script-based steps to fetch EPA data and plot the scatter
- add a setup step to ensure the data directory exists before writing artifacts
- keep the existing dependency sanity check and artifact upload paths unchanged

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948558f17c083318f1df172998e6de2)