### PR TITLE
Fix week start select reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,7 +276,7 @@
     }
 
     function syncWeekRange(startWeek, endWeek) {
-      const start = Number(startWeekSelect.value);
+      const start = Number(weekStartSelect.value);
       const end = Number(endWeekSelect.value);
       if (start > end) {
         weekEndSelect.value = start;


### PR DESCRIPTION
## Summary
- fix syncWeekRange to use the correct weekStartSelect variable
- prevent runtime error when syncing week range selections

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e145f68083319e65754340d7e6db)