### PR TITLE
Add manual trigger description for EPA workflow

### DIFF
--- a/.github/workflows/update-epa-data.yml
+++ b/.github/workflows/update-epa-data.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 12 * * TUE'
   workflow_dispatch:
+    description: "Run EPA data refresh on demand"
     inputs:
       mode:
         description: "Choose update_current to refresh active season; backfill_season for historical rebuild"


### PR DESCRIPTION
## Summary
- add a manual workflow_dispatch description to the EPA data update workflow

## Testing
- not run (not needed for workflow text-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a029135648331a84ed7f093180599)