### PR TITLE
Add smoke test workflow and harden EPA data automation

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,43 @@
+name: Smoke test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Fetch sample EPA data
+        run: |
+          python -m scripts.fetch_epa --season 2024 --db data/epa.sqlite --week-start 1 --week-end 1
+
+      - name: Export sample EPA JSON
+        run: |
+          python -m scripts.export_epa_json --db data/epa.sqlite --output data/epa_sample.json
+
+      - name: Validate JSON contains 2024
+        run: |
+          python - <<'PY'
+import json
+from pathlib import Path
+payload = json.loads(Path('data/epa_sample.json').read_text())
+if '2024' not in payload.get('seasons', {}):
+    raise SystemExit('Season 2024 missing from exported JSON')
+print('Validated season 2024 presence in data/epa_sample.json')
+PY

--- a/.github/workflows/update-epa-data.yml
+++ b/.github/workflows/update-epa-data.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: true
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -80,6 +81,11 @@ PY
             season="$season_end"
             if [ "$season_start" -gt "$season_end" ]; then
               echo "season_start ($season_start) cannot be greater than season_end ($season_end)" >&2
+              exit 1
+            fi
+            if [ $((season_end - season_start)) -gt 10 ]; then
+              echo "Requested backfill range ${season_start}-${season_end} exceeds 10 seasons." >&2
+              echo "Re-run in smaller chunks (e.g., 5-year blocks) to avoid timeouts." >&2
               exit 1
             fi
           else
@@ -149,6 +155,11 @@ PY
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync with remote
+        run: |
+          git fetch origin
+          git pull --rebase
 
       - name: Commit and push updates
         run: |

--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ can also be triggered manually with three modes:
 Each run downloads play-by-play data with `nflreadpy`, aggregates weekly team
 EPA into `data/epa.sqlite`, exports the JSON consumed by the static chart to
 `data/epa_sample.json`, and commits the updated artifacts back to the
-repository.
-
-Make sure GitHub Pages is configured to **Deploy from a branch** (root folder)
-so the latest `index.html` and `data/epa_sample.json` are served directly from
-the repository. The GitHub Actions UI shows **Run workflow** only after the
+repository. The GitHub Actions UI shows **Run workflow** only after the
 workflow file exists on the default branch (and you have write access).
+
+## GitHub Pages Settings
+
+Open **Settings → Pages** and select **Deploy from a branch → main → /(root)**
+so GitHub Pages serves `index.html` and `data/epa_sample.json` directly from the
+repository without an extra build step.
 
 ### Run the update locally
 
@@ -41,10 +43,9 @@ Swap in the season you need, then open `index.html` (or visit
 
 - `update_current`: runs weekly automatically.
 - `backfill_season`: run manually once per season (provide `season`).
-- `backfill_range`: run with `season_start=2000` and leave `season_end` blank to
-  rebuild 2000→current in one go, or split into smaller ranges (e.g.,
-  `season_start=2000`, `season_end=2010`, then `2011` onward) if runtime is a
-  concern.
+- `backfill_range`: use shorter ranges to avoid long-running jobs (e.g.,
+  `season_start=2000`, `season_end=2004`, then `2005-2009`, and so on) instead
+  of attempting a single 2000→current backfill.
 
 ## Preview locally (optional)
 


### PR DESCRIPTION
## Summary
- add a fast smoke-test workflow to verify data export on pushes and pull requests
- harden the EPA data update workflow with full fetch history, remote sync, and guarded backfill ranges
- document GitHub Pages settings and recommended chunked backfill usage for long ranges

## Testing
- not run (CI only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae0d697d483318df846c7c50abb43)