### PR TITLE
Make EPA chart responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,11 +84,29 @@
       box-shadow: 0 8px 18px rgba(37, 99, 235, 0.2);
     }
 
-    canvas {
+    .chart-wrap {
+      position: relative;
+      width: 100%;
+      /* “Reasonable size” across laptop + mobile */
+      height: clamp(360px, 65vh, 720px);
       border: 1px solid var(--border);
       border-radius: 12px;
       padding: 0.75rem;
       background: #fff;
+      overflow: hidden;
+    }
+
+    .chart-wrap canvas {
+      display: block;
+      width: 100% !important;
+      height: 100% !important;
+    }
+
+    @media (max-width: 640px) {
+      .chart-wrap {
+        height: clamp(320px, 60vh, 520px);
+        padding: 0.5rem;
+      }
     }
 
     .notice {
@@ -132,7 +150,9 @@
       </div>
     </section>
 
-    <canvas id="epa-chart" width="1000" height="620" aria-label="EPA scatter chart" role="img"></canvas>
+      <div class="chart-wrap">
+        <canvas id="epa-chart" aria-label="EPA scatter chart" role="img"></canvas>
+      </div>
 
     <footer>
       <p><strong>Tip:</strong> values shown come from a bundled dataset (data/epa.json). Replace that file with your own weekly EPA snapshots to publish updated charts on GitHub Pages.</p>


### PR DESCRIPTION
## Summary
- wrap EPA chart in responsive container with clamped height for desktop and mobile
- ensure canvas fills container and adjust padding on small screens
- replace fixed canvas element with responsive wrapper in markup

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bf335b90483318dc49293619b6661)