### PR TITLE
Update EPA workflow validation and backfill selection

### DIFF
--- a/.github/workflows/update-epa-data.yml
+++ b/.github/workflows/update-epa-data.yml
@@ -24,6 +24,10 @@ on:
       season_end:
         description: "End season year (optional; defaults to current season when mode=backfill_range)"
         required: false
+  push:
+    branches: [ main ]
+    paths:
+      - .github/workflows/update-epa-data.yml
 
 concurrency:
   group: epa-data
@@ -62,6 +66,58 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
+
+      - name: Determine next season to backfill (scheduled)
+        if: ${{ github.event_name == 'schedule' }}
+        id: auto
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+db_path = Path("data/epa.sqlite")
+db_path.parent.mkdir(parents=True, exist_ok=True)
+
+now = datetime.utcnow()
+current_season = now.year if now.month >= 9 else now.year - 1
+start_season = 2000
+
+seasons_in_db = set()
+if db_path.exists():
+    conn = sqlite3.connect(str(db_path))
+    try:
+        try:
+            rows = conn.execute("SELECT DISTINCT season FROM team_epa_weekly").fetchall()
+        except sqlite3.OperationalError as exc:
+            # If table doesn't exist yet, treat as empty.
+            if "no such table" in str(exc):
+                rows = []
+            else:
+                raise
+        seasons_in_db = {int(r[0]) for r in rows if r and r[0] is not None}
+    finally:
+        conn.close()
+
+missing = [s for s in range(start_season, current_season + 1) if s not in seasons_in_db]
+
+# Pick newest missing first so you reach 2025 quickly, but skip current season to avoid duplicate work
+missing_hist = [s for s in missing if s != current_season]
+season_to_fetch = max(missing_hist) if missing_hist else None
+
+out = Path(os.environ["GITHUB_OUTPUT"])
+with out.open("a", encoding="utf-8") as f:
+    if season_to_fetch is None:
+        f.write("did_find_season=false\n")
+    else:
+        f.write("did_find_season=true\n")
+        f.write(f"season_to_fetch={season_to_fetch}\n")
+
+print("seasons_in_db_count=", len(seasons_in_db))
+print("season_to_fetch=", season_to_fetch)
+PY
 
       - name: Determine season target
         id: season
@@ -135,7 +191,7 @@ jobs:
           python -m scripts.fetch_epa --season "$season" --db data/epa.sqlite --include-playoffs
           python -c "import sqlite3; c=sqlite3.connect('data/epa.sqlite'); c.execute('PRAGMA wal_checkpoint(TRUNCATE);'); c.close()"
           rm -f data/epa.sqlite-wal data/epa.sqlite-shm
-          
+
       - name: Refresh SQLite cache (range)
         if: ${{ steps.season.outputs.mode == 'backfill_range' }}
         run: |
@@ -149,24 +205,64 @@ jobs:
             rm -f data/epa.sqlite-wal data/epa.sqlite-shm
           done
 
+      - name: Fetch next missing season (scheduled)
+        if: ${{ github.event_name == 'schedule' && steps.auto.outputs.did_find_season == 'true' }}
+        run: |
+          set -euo pipefail
+          season="${{ steps.auto.outputs.season_to_fetch }}"
+          echo "Auto-backfilling missing season: $season"
+          python -m scripts.fetch_epa --season "$season" --db data/epa.sqlite --include-playoffs
+          python -c "import sqlite3; c=sqlite3.connect('data/epa.sqlite'); c.execute('PRAGMA wal_checkpoint(TRUNCATE);'); c.close()"
+          rm -f data/epa.sqlite-wal data/epa.sqlite-shm
+
       - name: Export static JSON
         run: |
           python -m scripts.export_epa_json --db data/epa.sqlite --output data/epa.json
 
       - name: Validate exported payload
+        env:
+          MODE: ${{ steps.season.outputs.mode }}
+          TARGET_SEASON: ${{ steps.season.outputs.season }}
+          RANGE_START: ${{ steps.season.outputs.season_start }}
+          RANGE_END: ${{ steps.season.outputs.season_end }}
+          SEASON_TO_FETCH: ${{ steps.auto.outputs.season_to_fetch }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           python - <<'PY'
 import json
+import os
 from pathlib import Path
 
 payload = json.loads(Path("data/epa.json").read_text())
 seasons = payload.get("seasons", {})
-if "2025" not in seasons:
-    raise SystemExit("Season 2025 missing from export")
-teams = len(seasons["2025"].get("teams", []))
-if teams < 28:
-    raise SystemExit(f"Expected >= 28 teams for 2025, got {teams}")
-print("OK: 2025 present with", teams, "teams")
+if not seasons:
+    raise SystemExit("No seasons found in export")
+
+mode = os.environ.get("MODE", "")
+target = os.environ.get("TARGET_SEASON", "")
+start = os.environ.get("RANGE_START", "")
+end = os.environ.get("RANGE_END", "")
+event = os.environ.get("EVENT_NAME", "")
+season_to_fetch = os.environ.get("SEASON_TO_FETCH", "").strip()
+
+# Validate what *this run* claims to have generated
+if mode == "backfill_range":
+    if not start or not end:
+        raise SystemExit("backfill_range requires RANGE_START and RANGE_END")
+    s = int(start); e = int(end)
+    missing = [str(y) for y in range(s, e + 1) if str(y) not in seasons]
+    if missing:
+        raise SystemExit(f"Missing seasons in export: {', '.join(missing)}")
+else:
+    if target and str(target) not in seasons:
+        raise SystemExit(f"Target season {target} missing from export")
+
+# If scheduled run also backfilled a season, validate that too
+if event == "schedule" and season_to_fetch:
+    if season_to_fetch not in seasons:
+        raise SystemExit(f"Scheduled backfill expected season {season_to_fetch} in export")
+
+print("Export validation passed")
 PY
 
       - name: Final checkpoint before commit


### PR DESCRIPTION
## Summary
- validate exported JSON against the requested season or range instead of hard-requiring 2025
- skip duplicating scheduled backfill work by omitting the current season and add push trigger for manual run via merge
- keep scheduled backfill selection prioritizing newest missing seasons with safer validation coverage

## Testing
- not run (workflow change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c053f37a483319ab8fd676f2be48b)