### PR TITLE
Add comment trigger to run EPA workflow from GitHub

### DIFF
--- a/.github/workflows/comment-trigger-epa.yml
+++ b/.github/workflows/comment-trigger-epa.yml
@@ -1,0 +1,98 @@
+name: Comment-triggered EPA update
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  dispatch:
+    if: startsWith(github.event.comment.body, '/update-epa') && (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse command and trigger workflow
+        id: trigger
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const raw = (context.payload.comment.body || '').trim();
+            const tokens = raw.split(/\s+/).slice(1);
+            const inputs = {
+              mode: 'update_current',
+              season: '',
+              season_start: '',
+              season_end: '',
+            };
+
+            for (const token of tokens) {
+              const [key, value = ''] = token.split('=', 2);
+              if (key in inputs) {
+                inputs[key] = value;
+              }
+            }
+
+            const ref = context.payload.repository?.default_branch || 'main';
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'update-epa-data.yml',
+              ref,
+              inputs,
+            });
+
+            core.setOutput('inputs', JSON.stringify(inputs));
+
+      - name: Acknowledge trigger
+        uses: actions/github-script@v7
+        env:
+          COMMAND_INPUTS: ${{ steps.trigger.outputs.inputs }}
+        with:
+          script: |
+            const inputs = JSON.parse(process.env.COMMAND_INPUTS || '{}');
+            const target = [
+              `mode=${inputs.mode || 'update_current'}`,
+              inputs.season ? `season=${inputs.season}` : null,
+              inputs.season_start ? `season_start=${inputs.season_start}` : null,
+              inputs.season_end ? `season_end=${inputs.season_end}` : null,
+            ].filter(Boolean).join(', ');
+
+            const body = [
+              '✅ Triggered **Update EPA data** via workflow dispatch.',
+              target ? `Inputs: ${target}` : 'Inputs: mode=update_current',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+  unauthorized:
+    if: startsWith(github.event.comment.body, '/update-epa') && !(
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reply with permissions warning
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '❌ `/update-epa` is limited to repository collaborators. Please ask a maintainer to run it.',
+            });

--- a/scripts/trigger_update_workflow.sh
+++ b/scripts/trigger_update_workflow.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Trigger the "Update EPA data" GitHub Actions workflow from the CLI.
+# Requires GitHub CLI (`gh`) and a token with `workflow` scope (`GH_TOKEN` or
+# `GITHUB_TOKEN`). Usage examples:
+#
+#   ./scripts/trigger_update_workflow.sh                    # update_current on default branch
+#   ./scripts/trigger_update_workflow.sh backfill_season 2023
+#   ./scripts/trigger_update_workflow.sh backfill_range '' 2000 2024
+#
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI (gh) is required to trigger the workflow" >&2
+  exit 1
+fi
+
+mode=${1:-update_current}
+season=${2:-}
+season_start=${3:-}
+season_end=${4:-}
+
+args=(workflow run update-epa-data.yml)
+args+=(--ref "${GITHUB_REF:-main}")
+args+=(-f mode="${mode}")
+
+if [[ -n "${season}" ]]; then
+  args+=(-f season="${season}")
+fi
+if [[ -n "${season_start}" ]]; then
+  args+=(-f season_start="${season_start}")
+fi
+if [[ -n "${season_end}" ]]; then
+  args+=(-f season_end="${season_end}")
+fi
+
+exec gh "${args[@]}"


### PR DESCRIPTION
## Summary
- add an issue/PR comment workflow that dispatches the Update EPA data job via `/update-epa` commands
- document comment-based triggering for collaborators when the Actions UI hides the Run button

## Testing
- not run (not needed)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c1f8d1a748331affff7aba833e293)